### PR TITLE
fix(deploy): add proper Nuxt.js GitHub Pages workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,53 @@
+name: Deploy Nuxt.js to GitHub Pages
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Generate static files
+        run: npm run generate
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./.output/public
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary

Fixes GitHub Pages deployment failures by replacing Jekyll build process with proper Nuxt.js static site generation.

## Problem
- GitHub Pages was configured to use Jekyll build (`actions/jekyll-build-pages`)
- Our project is a Nuxt.js application, not a Jekyll site
- Jekyll was failing with: `No such file or directory @ dir_chdir0 - /github/workspace/docs`

## Solution
- ✅ Added proper GitHub Actions workflow for Nuxt.js
- ✅ Uses `npm run generate` to build static site  
- ✅ Deploys from `.output/public` directory (not `/docs`)
- ✅ Tested locally - build succeeds

## Acceptance Criteria
- [x] Local build passes (`npm run generate`)
- [ ] GitHub Actions workflow runs successfully  
- [ ] Site deploys to GitHub Pages
- [ ] All images and assets load correctly

## Risk Assessment
**Low risk** - This only changes the deployment method, not the site content or functionality.

🤖 Generated with [Claude Code](https://claude.ai/code)